### PR TITLE
Fix index setting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,14 +3,11 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
+indent_size = 2
 indent_style = space
 insert_final_newline = true
 max_line_length = 120
-tab_width = 4
-
-[*.lua]
-indent_style = tab
+tab_width = 2
 
 [.gitconfig]
 indent_size = 2


### PR DESCRIPTION
nvimの設定のLuaを変更する場合に、Tabを入れるとSpacex2が入って欲しいが、Tabが入っていた。
これは、nvimと`.editconfig`で衝突していたのでそれを変更した。